### PR TITLE
改变上传读数的权限

### DIFF
--- a/duo/permissions.py
+++ b/duo/permissions.py
@@ -1,5 +1,8 @@
 from rest_framework.permissions import BasePermission, SAFE_METHODS
 
+# export default permissions
+from rest_framework.permissions import AllowAny, IsAuthenticated, IsAdminUser, IsAuthenticatedOrReadOnly
+
 class IsAdminOrReadOnly(BasePermission):
     def has_permission(self, request, view):
         if request.method in SAFE_METHODS:

--- a/duo/views.py
+++ b/duo/views.py
@@ -7,7 +7,7 @@ from django.core.cache import cache
 
 from .models import Node, NodePowerArchive
 from .serializers import NodeSerializer, NodePowerArchiveSimpleSerializer, NodePowerArchiveDetailSerializer
-from .permissions import IsAdminOrReadOnly
+from .permissions import IsAdminOrReadOnly, IsAuthenticatedOrReadOnly
 
 import json
 from django.utils.timezone import datetime, timedelta
@@ -39,7 +39,7 @@ class DeviceList(generics.ListCreateAPIView):
 
 class DevicePowerArchiveList(generics.ListCreateAPIView):
     queryset = NodePowerArchive.objects.all()  # descending by time
-    permission_classes = (IsAdminOrReadOnly, )
+    permission_classes = (IsAuthenticatedOrReadOnly, )
 
     def get_serializer_class(self):
         data_type = self.get_period_query_params()[2]


### PR DESCRIPTION
设备用普通账号登录的token可以上传读数，创建设备需要管理员权限。